### PR TITLE
Share songs via the hash portion of the URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,31 +3,6 @@
 
 <head>
     <script src="scripts.js"></script>
-    <script>
-        window.onload = function () {
-
-            var codeForm = document.getElementById("code")
-            function show() { codeForm.style.visibility = "visible"; }
-            function hide() { codeForm.style.visibility = "hidden"; }
-            function toggle() { codeForm.style.visibility == "visible" ? hide() : show(); }
-
-            document.getElementById("buttonprogram").addEventListener("click", toggle, false);
-            document.getElementById("tempo").value = "MEDIUM"
-
-            var hash = window.location.hash.substr(1)
-            if (hash !== "") {
-                var split = hash.split(",")
-                var tempo = split.shift()
-                var program = split.join(",")
-                if (!tempo || !program || !tempos[tempo.toLowerCase()]) {
-                    return;
-                }
-                document.getElementById("tempo").value = tempo
-                codeForm.value = program
-                show()
-            }
-        }
-    </script>
 
 
     <style>
@@ -152,7 +127,15 @@
             background-image: url("images/reset.png");
         }
 
-        #code {
+        .buttonright {
+            float: right;
+        }
+
+        .textshare {
+            width: *;
+        }
+
+        #code, #formshare {
             visibility: hidden;
         }
     </style>
@@ -256,7 +239,15 @@
             <br><br>
             Tempo: <input type="text" id="tempo" name="tempo">
             <br><br>
-            <button type="button" onClick="playSong()">PLAY</button>
+            <button id="buttonplay" type="button" onClick="playSong()">PLAY</button>
+            <button id="buttonshare" class="buttonright" type="button">SHARE</button>
+            <p>
+                <form id="formshare">
+                    <label for="textshare">URL:</label>
+                    <input name="textshare" id="textshare" class="textshare" type="text" readonly="true"/>
+                    <button id="buttoncopy" class="buttonright" type="button">COPY</button>
+                </form>
+            </p>
             <p>
                 <b>Example:</b>
                 <br>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,7 @@
             var codeForm = document.getElementById("code")
             function show() { codeForm.style.visibility = "visible"; }
             function hide() { codeForm.style.visibility = "hidden"; }
-            hide();
-            function toggle() { codeForm.style.visibility == "hidden" ? show() : hide(); }
+            function toggle() { codeForm.style.visibility == "visible" ? hide() : show(); }
 
             document.getElementById("buttonprogram").addEventListener("click", toggle, false);
             document.getElementById("tempo").value = "MEDIUM"
@@ -151,6 +150,10 @@
 
         .buttonreset {
             background-image: url("images/reset.png");
+        }
+
+        #code {
+            visibility: hidden;
         }
     </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,19 @@
 
             document.getElementById("buttonprogram").addEventListener("click", toggle, false);
             document.getElementById("tempo").value = "MEDIUM"
+
+            var hash = window.location.hash.substr(1)
+            if (hash !== "") {
+                var split = hash.split(",")
+                var tempo = split.shift()
+                var program = split.join(",")
+                if (!tempo || !program || !tempos[tempo.toLowerCase()]) {
+                    return;
+                }
+                document.getElementById("tempo").value = tempo
+                codeForm.value = program
+                show()
+            }
         }
     </script>
 

--- a/scripts.js
+++ b/scripts.js
@@ -1,3 +1,7 @@
+var codeForm;
+var shareForm;
+var shareText;
+
 var tempos = {
     "slow": 0.5,
     "medium": 0.75,
@@ -63,6 +67,8 @@ function playSong() {
         return;
     }
 
+    update();
+
     const base = 261.626 // frequency of middle C
     const y = Math.pow(2, 1 / 12) // frequency multiplier between 2 half notes
     var i;
@@ -89,7 +95,52 @@ function playSong() {
     oscillator.stop(time_elapsed);
 }
 
+function show() { codeForm.style.visibility = "visible"; }
+function hide() { codeForm.style.visibility = "hidden"; }
+function toggle() { codeForm.style.visibility == "visible" ? hide() : show(); }
 
+function update() {
+    shareText.value = window.location.href.replace(window.location.hash,"") + "#"
+    	+ document.getElementById("tempo").value + ","
+    	+ codeForm.value;
+}
 
+function share() {
+    shareForm.style.visibility = "visible";
+    update()
+}
 
+function copy() {
+    shareText.select();
+    shareText.setSelectionRange(0, Number.MAX_SAFE_INTEGER);
+    document.execCommand("copy");
+}
 
+window.onload = function () {
+
+    codeForm = document.getElementById("code");
+    shareForm = document.getElementById("formshare");
+    shareText = document.getElementById("textshare");
+
+    document.getElementById("buttonprogram").addEventListener("click", toggle, false);
+    document.getElementById("tempo").value = "MEDIUM"
+
+    
+    document.getElementById("buttonshare").addEventListener("click", share, false);
+
+    
+    document.getElementById("buttoncopy").addEventListener("click", copy, false);
+
+    var hash = window.location.hash.substr(1)
+    if (hash !== "") {
+        var split = hash.split(",")
+        var tempo = split.shift()
+        var program = split.join(",")
+        if (!tempo || !program || !tempos[tempo.toLowerCase()]) {
+            return;
+        }
+        document.getElementById("tempo").value = tempo
+        codeForm.value = program
+        show()
+    }
+}


### PR DESCRIPTION
This pull request adds a couple features, allowing the page to accept a song as part of the URL by appending `#tempo,notes` at the end, as well as adding a couple of buttons to both show a textline containing the full URL of the song and copy it to the clipboard. Only tested on Firefox and Chromium on Linux, and Firefox on Android.