### PR TITLE
Remove whitespace when creating share link

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -102,7 +102,7 @@ function toggle() { codeForm.style.visibility == "visible" ? hide() : show(); }
 function update() {
     shareText.value = window.location.href.replace(window.location.hash,"") + "#"
     	+ document.getElementById("tempo").value + ","
-    	+ codeForm.value;
+    	+ codeForm.value.replace(/\s+/g,"");
 }
 
 function share() {


### PR DESCRIPTION
Small addition to https://github.com/ChrisMusson/Programmable-Doorbell/pull/2 because spaces in the music code become "%20" in the share link. For example, `*71, *01, 00` becomes `*71,%20*01,%2000`.